### PR TITLE
Fix branch in docs build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,19 +4,19 @@ name: Pages
 on:
   push:
     branches:
-    - master
+    - main
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/setup-python@v2
-    - uses: actions/checkout@master
+    - uses: actions/checkout@main
       with:
-        fetch-depth: 0 
+        fetch-depth: 0
     - name: Build and Commit
       uses: sphinx-notes/pages@v2
     - name: Push changes
-      uses: ad-m/github-push-action@master
+      uses: ad-m/github-push-action@main
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         branch: gh-pages


### PR DESCRIPTION
This PR aims to fix a bug that slipped into #2 (we use `main` branch and another name was specified in the workflow file).