### PR TITLE
select only positive NES pathways

### DIFF
--- a/cansig/run/pipeline.py
+++ b/cansig/run/pipeline.py
@@ -194,6 +194,7 @@ def _get_pathways_and_scores(df: pd.DataFrame) -> List[Tuple[str, float]]:
     # TODO(Pawel): This is very hacky. Make configurable.
     new_df = df.groupby("Term").max()
     new_df = new_df[new_df["fdr"] < 0.05]
+    new_df = new_df[new_df["nes"] > 0]
     return list(new_df["nes"].items())
 
 


### PR DESCRIPTION
This is just a small change to select only the positive pathways with GSEA
We are not interested in negatives as they mean that the pathway is enriched elsewhere, not in the cluster