### PR TITLE
Fix heatmap generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ outputs/
 
 # Data (disable adding data files by default)
 # If really needed, use `git add --force FILENAME`
+*.pdf
+*.svg
 *.png
 *.jpeg
 *.jpg

--- a/cansig/gsea.py
+++ b/cansig/gsea.py
@@ -1,6 +1,6 @@
 """Gene expression analysis utilities."""
 import pathlib
-from typing import Iterable, Dict, List, Optional, Union
+from typing import Iterable, Dict, List, Optional, Union, Protocol
 from typing import get_args  # pytype: disable=import-error
 from typing import Literal  # pytype: disable=not-supported-yet
 
@@ -277,3 +277,26 @@ def score_signature(
 
     # save the correlation between the scores
     signature_df.corr(method=corr_method).to_csv(sig_correlation_file)
+
+
+class IPathwayFormatter(Protocol):
+    """Interface for formatters used to adjust pathway names."""
+
+    def format(self, pathway: str) -> str:
+        """Formats pathway name.
+
+        Args:
+            pathway: pathway name
+
+        Returns:
+             formatted pathway name
+        """
+        pass
+
+
+class DefaultFormatter(IPathwayFormatter):
+    """The default formatter, used to remove underscores
+    and split long pathway names into multiple lines."""
+
+    def format(self, pathway: str) -> str:
+        return pathway.replace("_", " ").replace(" ", "\n")

--- a/cansig/metaanalysis/heatmap.py
+++ b/cansig/metaanalysis/heatmap.py
@@ -176,7 +176,7 @@ def plot_heatmap(items: Iterable[HeatmapItem], settings: HeatmapSettings) -> plt
             ax.set_xticklabels(labels=[f"{i} {settings.vertical_name}" for i in vertical])
             ax.xaxis.set_tick_params(labeltop="on")
 
-    fig.subplots_adjust(wspace=0, hspace=0, top=0.97, bottom=0.02, left=0.03)
+    fig.subplots_adjust(wspace=0, hspace=0, top=0.95, bottom=0.02, left=0.03)
     return fig
 
 

--- a/cansig/metaanalysis/heatmap.py
+++ b/cansig/metaanalysis/heatmap.py
@@ -26,7 +26,7 @@ class HeatmapSettings(pydantic.BaseModel):
     value_min: Optional[float] = pydantic.Field(default=None)
     value_max: Optional[float] = pydantic.Field(default=None)
 
-    font_size: int = pydantic.Field(default=16)
+    font_size: int = pydantic.Field(default=12)
     spines_linewidth: float = pydantic.Field(default=1.25)
 
 
@@ -50,7 +50,12 @@ def _get_n_runs(items: Iterable[HeatmapItem]) -> int:
 
 
 def _calculate_figsize(
-    settings: HeatmapSettings, n_runs: int, n_vertical: int, n_horizontal: int, n_panel: int
+    settings: HeatmapSettings,
+    n_runs: int,
+    n_vertical: int,
+    n_horizontal: int,
+    n_panel: int,
+    offset_width: Optional[float] = None,
 ) -> Tuple[float, float]:
     # The tiles need the rectangle like base_width x height
     base_width = settings.tile_size * n_runs * n_vertical
@@ -58,7 +63,8 @@ def _calculate_figsize(
     # We will add some offset to the width to accommodate for panel names.
     # Note that this is heuristic, we haven't calibrated this properly
     # (plus, the offset should depend on the maximal length of the panel name)
-    offset_width = (settings.font_size / 8) * settings.tile_size
+    if offset_width is None:
+        offset_width = (settings.font_size / 5) * settings.tile_size
 
     width = base_width + offset_width
     return (width, height)
@@ -99,10 +105,6 @@ def plot_heatmap(items: Iterable[HeatmapItem], settings: HeatmapSettings) -> plt
     n_horizontal = len(horizontal)
     n_panel = len(panels)
     n_runs = _get_n_runs(items)
-
-    # TODO(Pawel): Remove this note
-    #  vertical = clusters
-    #  horizontal = latent dimensionality
 
     figsize = _calculate_figsize(
         settings=settings, n_runs=n_runs, n_vertical=n_vertical, n_horizontal=n_horizontal, n_panel=n_panel
@@ -172,5 +174,5 @@ def plot_heatmap(items: Iterable[HeatmapItem], settings: HeatmapSettings) -> plt
             ax.set_xticklabels(labels=[f"{i} {settings.vertical_name}" for i in vertical])
             ax.xaxis.set_tick_params(labeltop="on")
 
-    fig.subplots_adjust(wspace=0, hspace=0)
+    fig.subplots_adjust(wspace=0, hspace=0, top=0.97, bottom=0.02, left=0.03)
     return fig

--- a/cansig/multirun.py
+++ b/cansig/multirun.py
@@ -1,0 +1,38 @@
+import pathlib
+from typing import List
+
+import cansig.filesys as fs
+
+
+class MultirunDirectory(fs.StructuredDir):
+    def valid(self) -> bool:
+        # TODO(Pawel): Consider making this more elaborate.
+        return True
+
+    @property
+    def integration_directories(self) -> pathlib.Path:
+        return self.path / "integration"
+
+    @property
+    def postprocessing_directories(self) -> pathlib.Path:
+        return self.path / "postprocessing"
+
+    @property
+    def analysis_directory(self) -> pathlib.Path:
+        return self.path / "final_analysis"
+
+
+def get_valid_dirs(multirun_dir: MultirunDirectory) -> List[fs.PostprocessingDir]:
+    valid_dirs = []
+    invalid_dirs = []
+    for path in multirun_dir.postprocessing_directories.glob("*"):
+        wrapped_path = fs.PostprocessingDir(path)
+        if wrapped_path.valid():
+            valid_dirs.append(wrapped_path)
+        else:
+            invalid_dirs.append(path)
+
+    if invalid_dirs:
+        print(f"The following directories seem to be corrupted: {invalid_dirs}.")
+
+    return valid_dirs

--- a/cansig/run/heatmap.py
+++ b/cansig/run/heatmap.py
@@ -67,8 +67,10 @@ def generate_items(dirs: Iterable[fs.PostprocessingDir]) -> Iterable[hm.HeatmapI
     return items
 
 
-def generate_heatmap(dirs: Iterable[fs.PostprocessingDir]) -> plt.Figure:
+def generate_heatmap(dirs: Iterable[fs.PostprocessingDir], n_pathways: int) -> plt.Figure:
     items = generate_items(dirs)
+
+    items = hm.MostFoundItemsFilter(k=n_pathways).filter(items)
 
     settings = hm.HeatmapSettings(
         vertical_name="clusters",
@@ -83,6 +85,9 @@ def generate_heatmap(dirs: Iterable[fs.PostprocessingDir]) -> plt.Figure:
 def create_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser()
     parser.add_argument("multirun", type=str, help="Multirun directory.")
+    parser.add_argument(
+        "--n-pathways", type=int, default=5, help="The number of most consistently " "found pathways to be visualised."
+    )
     parser.add_argument(
         "--output", type=str, default="heatmap.pdf", help="Generated heatmap name. Default: heatmap.pdf"
     )
@@ -99,7 +104,7 @@ def main() -> None:
 
     directories = mr.get_valid_dirs(multirur_dir)
 
-    fig = generate_heatmap(directories)
+    fig = generate_heatmap(directories, n_pathways=args.n_pathways)
     fig.savefig(args.output)
 
 

--- a/cansig/run/heatmap.py
+++ b/cansig/run/heatmap.py
@@ -96,13 +96,13 @@ def create_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--output", type=str, default="heatmap.pdf", help="Generated heatmap name. Default: heatmap.pdf"
     )
-    parser.add_argument("--value-max", type=float, default=2.0, help="Upper value to plot the heatmap. Default: 2.0.")
+    parser.add_argument("--value-max", type=float, default=2.0, help="Upper value to plot the heatmap. Default: 2.0")
     parser.add_argument(
         "--pathway-sort-method",
         type=str,
-        default="count",
+        default="mean",
         choices=get_args(hm.PanelFilterTypes),
-        help="How the panels (pathways) should be sorted.",
+        help="How the panels (pathways) should be sorted. Default: by highest mean NES across the runs.",
     )
 
     return parser

--- a/cansig/run/heatmap.py
+++ b/cansig/run/heatmap.py
@@ -1,0 +1,92 @@
+"""Script for running the heatmap."""
+import argparse
+from typing import Iterable, List, Tuple
+
+import matplotlib.pyplot as plt  # pytype: disable=import-error
+import pandas as pd  # pytype: disable=import-error
+
+import cansig.cluster.api as cluster
+import cansig.filesys as fs
+import cansig.gsea as gsea
+import cansig.metaanalysis.heatmap as hm
+import cansig.models.api as models
+import cansig.multirun as mr
+
+
+def _get_pathways_and_scores(df: pd.DataFrame) -> List[Tuple[str, float]]:
+    # TODO(Pawel): This is very hacky. Make configurable.
+    new_df = df.groupby("Term").max()
+    new_df = new_df[new_df["fdr"] < 0.05]
+    new_df = new_df[new_df["nes"] > 0]
+    return list(new_df["nes"].items())
+
+
+def read_directory(directory: fs.PostprocessingDir, formatter: gsea.IPathwayFormatter) -> List[hm.HeatmapItem]:
+    # TODO(Pawel): This looks very hacky.
+    assert directory.valid()
+
+    cluster_settings = fs.read_settings(cluster.LeidenNClusterConfig, directory.cluster_settings)
+    n_cluster = cluster_settings.clusters
+
+    model_settings = fs.read_settings(models.SCVIConfig, directory.integration_settings)
+    n_latent = model_settings.n_latent
+
+    gsea_dataframe = pd.read_csv(directory.gsea_output)
+    items = _get_pathways_and_scores(gsea_dataframe)
+
+    return [
+        hm.HeatmapItem(
+            vertical=n_cluster,
+            horizontal=n_latent,
+            value=score,
+            panel=formatter.format(pathway),
+        )
+        for pathway, score in items
+    ]
+
+
+def generate_items(dirs: Iterable[fs.PostprocessingDir]) -> Iterable[hm.HeatmapItem]:
+    formatter = gsea.DefaultFormatter()
+
+    items = sum([read_directory(directory, formatter=formatter) for directory in dirs], [])
+    return items
+
+
+def generate_heatmap(dirs: Iterable[fs.PostprocessingDir]) -> plt.Figure:
+    items = generate_items(dirs)
+
+    settings = hm.HeatmapSettings(
+        vertical_name="clusters",
+        horizontal_name="dim",
+        # TODO(Pawel): Consider making this configurable.
+        value_min=0,
+        value_max=2,
+    )
+    return hm.plot_heatmap(items, settings=settings)
+
+
+def create_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("multirun", type=str, help="Multirun directory.")
+    parser.add_argument(
+        "--output", type=str, default="heatmap.pdf", help="Generated heatmap name. Default: heatmap.pdf"
+    )
+
+    return parser
+
+
+def main() -> None:
+    parser = create_parser()
+    args = parser.parse_args()
+
+    multirur_dir = mr.MultirunDirectory(args.multirun, create=False)
+    assert multirur_dir.valid(), "Multirun directory has invalid format."
+
+    directories = mr.get_valid_dirs(multirur_dir)
+
+    fig = generate_heatmap(directories)
+    fig.savefig(args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/cansig/run/pipeline.py
+++ b/cansig/run/pipeline.py
@@ -153,6 +153,12 @@ def create_parser() -> argparse.ArgumentParser:
             IMPORTANT: using this flag will automatically disable running the differential CNV on the anndata object",
         default=None,
     )
+    parser.add_argument(
+        "--n-pathways",
+        type=int,
+        default=5,
+        help="The number of most consistently found pathways to be plotted in the heatmap. Default: 5.",
+    )
     return parser
 
 
@@ -296,7 +302,7 @@ def main() -> None:
     directories = mr.get_valid_dirs(multirun_dir)
 
     # Now we run the metaanalysis (first generate the heatmap).
-    fig = run_heatmap.generate_heatmap(directories)
+    fig = run_heatmap.generate_heatmap(directories, n_pathways=args.n_pathways)
     fig.savefig(multirun_dir.path / "heatmap.pdf")
 
     # to find a representative directory, we first generate a list of HeatmapItems

--- a/cansig/run/pipeline.py
+++ b/cansig/run/pipeline.py
@@ -7,22 +7,20 @@ In the end, produces summary.
 import argparse
 import logging
 import pathlib
-from typing import Iterable, List, Tuple, Optional, Literal  # pytype: disable=not-supported-yet
-
-import matplotlib.pyplot as plt  # pytype: disable=import-error
-import pandas as pd  # pytype: disable=import-error
+from typing import Iterable, List, Optional, Literal  # pytype: disable=not-supported-yet
 
 import cansig.cluster.api as cluster
 import cansig.filesys as fs
 import cansig.gsea as gsea
-import cansig.metaanalysis.heatmap as heatmap
 import cansig.metaanalysis.repr_directory as repdir
 import cansig.plotting.plotting as plotting
 import cansig.models.api as models
 import cansig.models.scvi as _scvi
+import cansig.multirun as mr
 
 import cansig.run.integration as integration
 import cansig.run.postprocessing as postprocessing
+import cansig.run.heatmap as run_heatmap
 
 _TESTTYPE = Literal["mwu", "ttest"]
 _CORRTYPE = Literal["pearson", "spearman"]
@@ -187,7 +185,6 @@ def generate_gsea_config(args) -> gsea.GeneExpressionConfig:
 
 
 def generate_plotting_config(args) -> plotting.ScatterPlotConfig:
-
     return plotting.ScatterPlotConfig(
         dim_reduction=args.dim_reduction,
         signature_columns=args.sigcols,
@@ -208,30 +205,12 @@ def generate_clustering_configs(args) -> List[cluster.LeidenNClusterConfig]:
     return lst
 
 
-class MultirunDirectory(fs.StructuredDir):
-    def valid(self) -> bool:
-        # TODO(Pawel): Consider making this more elaborate.
-        return True
-
-    @property
-    def integration_directories(self) -> pathlib.Path:
-        return self.path / "integration"
-
-    @property
-    def postprocessing_directories(self) -> pathlib.Path:
-        return self.path / "postprocessing"
-
-    @property
-    def analysis_directory(self) -> pathlib.Path:
-        return self.path / "final_analysis"
-
-
 def single_integration_run(
     data_path: pathlib.Path,
     integration_config: models.SCVIConfig,
     clustering_configs: Iterable[cluster.LeidenNClusterConfig],
     gsea_config: gsea.GeneExpressionConfig,
-    multirun_dir: MultirunDirectory,
+    multirun_dir: mr.MultirunDirectory,
     plotting_config: plotting.ScatterPlotConfig,
     batch: str,
     plot: bool,
@@ -278,74 +257,6 @@ def single_integration_run(
             print(f"Caught exception {type(e)}: {e}.")
 
 
-def get_valid_dirs(multirun_dir: MultirunDirectory) -> List[fs.PostprocessingDir]:
-    valid_dirs = []
-    invalid_dirs = []
-    for path in multirun_dir.postprocessing_directories.glob("*"):
-        wrapped_path = fs.PostprocessingDir(path)
-        if wrapped_path.valid():
-            valid_dirs.append(wrapped_path)
-        else:
-            invalid_dirs.append(path)
-
-    if invalid_dirs:
-        print(f"The following directories seem to be corrupted: {invalid_dirs}.")
-
-    return valid_dirs
-
-
-def _get_pathways_and_scores(df: pd.DataFrame) -> List[Tuple[str, float]]:
-    # TODO(Pawel): This is very hacky. Make configurable.
-    new_df = df.groupby("Term").max()
-    new_df = new_df[new_df["fdr"] < 0.05]
-    new_df = new_df[new_df["nes"] > 0]
-    return list(new_df["nes"].items())
-
-
-def read_directory(directory: fs.PostprocessingDir, formatter: gsea.IPathwayFormatter) -> List[heatmap.HeatmapItem]:
-    # TODO(Pawel): This looks very hacky.
-    assert directory.valid()
-
-    cluster_settings = fs.read_settings(cluster.LeidenNClusterConfig, directory.cluster_settings)
-    n_cluster = cluster_settings.clusters
-
-    model_settings = fs.read_settings(models.SCVIConfig, directory.integration_settings)
-    n_latent = model_settings.n_latent
-
-    gsea_dataframe = pd.read_csv(directory.gsea_output)
-    items = _get_pathways_and_scores(gsea_dataframe)
-
-    return [
-        heatmap.HeatmapItem(
-            vertical=n_cluster,
-            horizontal=n_latent,
-            value=score,
-            panel=formatter.format(pathway),
-        )
-        for pathway, score in items
-    ]
-
-
-def generate_items(dirs: Iterable[fs.PostprocessingDir]) -> Iterable[heatmap.HeatmapItem]:
-    formatter = gsea.DefaultFormatter()
-
-    items = sum([read_directory(directory, formatter=formatter) for directory in dirs], [])
-    return items
-
-
-def generate_heatmap(dirs: Iterable[fs.PostprocessingDir]) -> plt.Figure:
-    items = generate_items(dirs)
-
-    settings = heatmap.HeatmapSettings(
-        vertical_name="clusters",
-        horizontal_name="dim",
-        # TODO(Pawel): Consider making this configurable.
-        value_min=0,
-        value_max=2,
-    )
-    return heatmap.plot_heatmap(items, settings=settings)
-
-
 def main() -> None:
     # Read the CLI arguments
     parser = create_parser()
@@ -353,7 +264,7 @@ def main() -> None:
     validate_args(args)
 
     # Create a new directory, storing all the generated results
-    multirun_dir = MultirunDirectory(path=args.output, create=True)
+    multirun_dir = mr.MultirunDirectory(path=args.output, create=True)
 
     # Now for each integration algorithm, we run all specified clusterings.
     # We catch the errors at this stage
@@ -382,15 +293,14 @@ def main() -> None:
 
     # We have all the data generated, but perhaps some of these are corrupted.
     # Let's filter out these which look valid.
-    directories = get_valid_dirs(multirun_dir)
+    directories = mr.get_valid_dirs(multirun_dir)
 
     # Now we run the metaanalysis (first generate the heatmap).
-    fig = generate_heatmap(directories)
-    fig.tight_layout()
+    fig = run_heatmap.generate_heatmap(directories)
     fig.savefig(multirun_dir.path / "heatmap.pdf")
 
     # to find a representative directory, we first generate a list of HeatmapItems
-    items = generate_items(directories)
+    items = run_heatmap.generate_items(directories)
     chosen_directory = repdir.find_representative_run(
         items=items, directories=directories, settings=repdir.ReprDirectoryConfig()
     )

--- a/tests/metaanalysis/test_heatmap.py
+++ b/tests/metaanalysis/test_heatmap.py
@@ -1,0 +1,41 @@
+import cansig.metaanalysis.heatmap as hm
+
+
+def create_item(panel: str, score: float) -> hm.HeatmapItem:
+    return hm.HeatmapItem(
+        panel=panel,
+        value=score,
+        vertical=3,
+        horizontal=3,
+    )
+
+
+def test_most_found() -> None:
+    items = (
+        [create_item(panel="a", score=i) for i in range(4)]
+        + [create_item(panel="b", score=1) for _ in range(3)]
+        + [create_item(panel="c", score=1000)]
+    )
+
+    filter1 = hm.MostFoundItemsFilter(k=1)
+    filter2 = hm.MostFoundItemsFilter(k=2)
+    filter3 = hm.MostFoundItemsFilter(k=3)
+
+    assert filter1.filter(items) == items[:4]
+    assert filter2.filter(items) == items[:7]
+    assert filter3.filter(items) == items
+
+
+def test_highest_median() -> None:
+    items = (
+        [create_item(panel="a", score=i / 3) for i in range(4)]
+        + [create_item(panel="b", score=1) for _ in range(3)]
+        + [create_item(panel="c", score=1000)]
+        + [create_item(panel="d", score=290) for _ in range(2)]
+    )
+
+    filter1 = hm.HighestScoreFilter(k=1, method="median")
+    filter2 = hm.HighestScoreFilter(k=2, method="median")
+
+    assert filter1.filter(items) == [items[-3]]
+    assert filter2.filter(items) == items[-3:]

--- a/tests/test_gsea.py
+++ b/tests/test_gsea.py
@@ -1,0 +1,14 @@
+from typing import Tuple
+
+import pytest  # pytype: disable=import-error
+
+import cansig.gsea as cgsea
+
+
+@pytest.mark.parametrize("input_output", [("SOME_PATHWAY", "SOME\nPATHWAY"), ("SOME PATHWAY", "SOME\nPATHWAY")])
+def test_default_formatter(input_output: Tuple[str, str]) -> None:
+    inp, out = input_output
+
+    formatter = cgsea.DefaultFormatter()
+    out_ = formatter.format(inp)
+    assert out_ == out


### PR DESCRIPTION
This PR:
- refactors the code, so that it's now better structured (in particular, you can draw the heatmap using a separate script);
- somewhat resolves #46 – if someone tried to change the font size, they could observe weird behaviour (but calculating this properly is beyond my matplotlib skills);
- adds filtering for `n` "most consistent pathways", i.e., it resolves #28 .

As a demo I attach two files, generated using the following commands (`testrun` is a small example output directory):
```
$ python -m cansig.run.heatmap testrun --n-pathways 5 --output heatmap-5.pdf
$ python -m cansig.run.heatmap testrun --n-pathways 7 --output heatmap-7.pdf
```
[heatmap-5.pdf](https://github.com/BoevaLab/CanSig/files/8872391/heatmap-5.pdf)
[heatmap-7.pdf](https://github.com/BoevaLab/CanSig/files/8872392/heatmap-7.pdf)

