### PR TITLE
Add log counts

### DIFF
--- a/cansig/_preprocessing/quality_control.py
+++ b/cansig/_preprocessing/quality_control.py
@@ -2,6 +2,7 @@ import logging
 from typing import Optional
 
 import anndata as ad  # pytype: disable=import-error
+import numpy as np
 import scanpy as sc  # pytype: disable=import-error
 
 from cansig.types import Pathlike
@@ -39,7 +40,7 @@ def quality_control(
     adata = adata[adata.obs["pct_counts_mt"] < threshold_mt].copy()
     sc.pp.filter_cells(adata, min_genes=min_genes)
     filter_cells = adata.n_obs
-
+    adata.obs["log_counts"] = np.log(adata.obs["n_counts"])
     _LOGGER.info(f"Finished qc with {adata.n_obs} cells remaining and removed {raw_cells - filter_cells} cells.")
 
     return adata

--- a/tests/preprocessing/test_quality_control.py
+++ b/tests/preprocessing/test_quality_control.py
@@ -42,3 +42,10 @@ class TestQualityControl:
 
         adata = quality_control(adata, min_counts=0, max_counts=999999999, min_genes=min_genes, threshold_mt=100.0)
         assert np.greater_equal(adata.X.sum(1), min_genes).all()
+
+    def test_log_counts(self):
+        X = np.array([[1000, 1000, 1000], [500, 1000, 1000], [100, 200, 100], [200, 300, 200]])
+        adata = ad.AnnData(X=X)
+        adata = quality_control(adata, min_counts=0, max_counts=999999999, min_genes=0, threshold_mt=100.0)
+        assert "log_counts" in adata.obs.columns
+        assert np.allclose(np.exp(adata.obs["log_counts"]), adata.obs["n_counts"].values)


### PR DESCRIPTION
This PR adds log counts during the preprocessing. This can be a useful covariate for downstream tasks.