### PR TITLE
Fix issue with batch column and add number of genes as a pipeline parameter 

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -17,9 +17,11 @@ jobs:
       with:
         fetch-depth: 0
     - name: Install theme
-      run: pip install "sphinx<6" pydata-sphinx-theme
+      run: pip install pydata-sphinx-theme
     - name: Build and Commit
       uses: sphinx-notes/pages@v2
+      with:
+        sphinx_version: '5.3.0'
     - name: Push changes
       uses: ad-m/github-push-action@master
       with:

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -17,7 +17,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Install theme
-      run: pip install pydata-sphinx-theme==0.10.1
+      run: pip install "sphinx<6" pydata-sphinx-theme
     - name: Build and Commit
       uses: sphinx-notes/pages@v2
     - name: Push changes

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -17,7 +17,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Install theme
-      run: pip install pydata-sphinx-theme
+      run: pip install pydata-sphinx-theme==0.10.1
     - name: Build and Commit
       uses: sphinx-notes/pages@v2
     - name: Push changes

--- a/.github/workflows/docs-test.yml
+++ b/.github/workflows/docs-test.yml
@@ -17,7 +17,9 @@ jobs:
       with:
         fetch-depth: 0
     - name: Install theme
-      run: pip install "sphinx<6" pydata-sphinx-theme
+      run: pip install pydata-sphinx-theme
     - name: Build and Commit
       uses: sphinx-notes/pages@v2
+      with:
+        sphinx_version: '5.3.0'
 

--- a/.github/workflows/docs-test.yml
+++ b/.github/workflows/docs-test.yml
@@ -17,7 +17,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Install theme
-      run: pip install pydata-sphinx-theme==0.10.1
+      run: pip install "sphinx<6" pydata-sphinx-theme
     - name: Build and Commit
       uses: sphinx-notes/pages@v2
 

--- a/.github/workflows/docs-test.yml
+++ b/.github/workflows/docs-test.yml
@@ -17,7 +17,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Install theme
-      run: pip install pydata-sphinx-theme
+      run: pip install pydata-sphinx-theme==0.10.1
     - name: Build and Commit
       uses: sphinx-notes/pages@v2
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -79,7 +79,7 @@ html_theme = "pydata_sphinx_theme"
 html_static_path = ["_static"]
 
 # Options for the theme, as specified there:
-# https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/configuring.html
+# https://pydata-sphinx-theme.readthedocs.io/en/stable/
 
 html_theme_options = {
     "icon_links": [

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,4 +6,4 @@ pytest
 pytest-cov
 pytest-xdist
 pytype
-sphinx
+sphinx<6

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ seaborn
 scikit-learn
 scipy
 scvi-tools
-sphinx
+sphinx<6
 statsmodels
 protobuf~=3.19.0
 # requirements-dev.txt

--- a/src/cansig/metasignatures/clustering.py
+++ b/src/cansig/metasignatures/clustering.py
@@ -184,7 +184,7 @@ def _remove_patient_unique_ms(
         if ms == -1:
             continue
         ms_df = df[df.metamembership == ms]
-        pct_df = ms_df["sample_id"].value_counts() / ms_df.shape[0]
+        pct_df = ms_df[batch_key].value_counts() / ms_df.shape[0]
         if (pct_df > pat_specific_threshold).sum() > 0:
             _LOGGER.info(f"Removing ms {ms} because patient-specific")
             ms_to_remove.append(ms)

--- a/src/cansig/metasignatures/utils.py
+++ b/src/cansig/metasignatures/utils.py
@@ -220,6 +220,7 @@ def plot_metamembership(
     prob_metamembership: pd.DataFrame,
     integration_path: pl.Path,
     resdir: pl.Path,
+    batch_column: str,
 ) -> None:
 
     latent_representations = pd.read_csv(integration_path / "latent-representations.csv", index_col=0, header=None)
@@ -232,7 +233,7 @@ def plot_metamembership(
     plotting_config = plotting.ScatterPlotConfig(
         dim_reduction="both",
         signature_columns=list(metamembership.columns) + list(prob_metamembership.columns),
-        batch_column="sample_id",
+        batch_column=batch_column,
         ncols=2,
     )
 

--- a/src/cansig/models/api.py
+++ b/src/cansig/models/api.py
@@ -1,4 +1,7 @@
-from cansig.models.scvi import SCVIConfig, SCVI
-from cansig.models.cansig import CanSigConfig, CanSigWrapper
+from cansig.models.scvi import SCVIConfig, SCVI  # pytype: disable=import-error
+from cansig.models.cansig import CanSigConfig, CanSigWrapper  # pytype: disable=import-error
 
-__all__ = ["SCVI", "SCVIConfig", "CanSigConfig", "CanSigWrapper"]
+import cansig.models.scvi as module_scvi  # pytype: disable=import-error
+import cansig.models.cansig as module_cansig  # pytype: disable=import-error
+
+__all__ = ["SCVI", "SCVIConfig", "CanSigConfig", "CanSigWrapper", "module_scvi", "module_cansig"]

--- a/src/cansig/run/integration.py
+++ b/src/cansig/run/integration.py
@@ -51,6 +51,10 @@ class Arguments(Protocol):
     def log(self) -> pathlib.Path:
         raise NotImplementedError
 
+    @property
+    def n_top_genes(self) -> int:
+        raise NotImplementedError
+
 
 def parse_args() -> Arguments:
     parser = argparse.ArgumentParser()
@@ -63,6 +67,9 @@ def parse_args() -> Arguments:
     parser.add_argument("--output", type=pathlib.Path, help="Output directory.", default=default_output)
     parser.add_argument(
         "--log", type=pathlib.Path, help="Where the log file should be saved.", default=pathlib.Path("integration.log")
+    )
+    parser.add_argument(
+        "--n-top-genes", type=int, default=2000, help="The number of most highly variable genes to use."
     )
 
     args = parser.parse_args()
@@ -112,11 +119,13 @@ def main(args: Arguments) -> None:
         config = models.SCVIConfig(
             batch=args.batch,
             n_latent=args.latent,
+            preprocessing=models.module_scvi.PreprocessingConfig(n_top_genes=args.n_top_genes),
         )
     elif args.model == "cansig":
         config = models.CanSigConfig(
             batch=args.batch,
             n_latent=args.latent,
+            preprocessing=models.module_cansig.PreprocessingConfig(n_top_genes=args.n_top_genes),
         )
     else:
         raise NotImplementedError(f"Model {args.model} is not implemented.")

--- a/src/cansig/run/metasignatures.py
+++ b/src/cansig/run/metasignatures.py
@@ -198,6 +198,7 @@ def plot_latent_score(
     integ_dir: Optional[Union[str, pl.Path]],
     cell_metamembership: pd.DataFrame,
     prob_cellmetamembership: pd.DataFrame,
+    batch_column: str,
 ) -> None:
     utils.plot_score_UMAP(adata=adata, meta_signatures=meta_signatures, resdir=resdir.figures_output)
 
@@ -212,6 +213,7 @@ def plot_latent_score(
         prob_metamembership=prob_cellmetamembership,
         integration_path=integ_path,
         resdir=resdir.figures_output,
+        batch_column=batch_column,
     )
 
 
@@ -329,6 +331,7 @@ def run_metasignatures(
             integ_dir=integ_dir,
             cell_metamembership=cell_metamembership,
             prob_cellmetamembership=prob_cellmetamembership,
+            batch_column=batch,
         )
 
     _LOGGER.info("Performing GSEA.")

--- a/src/cansig/run/pipeline.py
+++ b/src/cansig/run/pipeline.py
@@ -186,6 +186,9 @@ def create_parser() -> argparse.ArgumentParser:
         "running the differential CNV on the anndata object",
         default=None,
     )
+    parser.add_argument(
+        "--n-top-genes", type=int, default=2_000, help="Number of the most highly variable genes to use. Default: 2000."
+    )
 
     # CanSig Args
     parser.add_argument("--n-latent-batch-effect", type=int, default=5)
@@ -222,6 +225,7 @@ def generate_model_configs(args) -> List[Union[models.SCVIConfig, models.CanSigC
                     train=_scvi.TrainConfig(max_epochs=args.max_epochs),
                     continuous_covariates=args.continuous_covariates,
                     discrete_covariates=args.discrete_covariates,
+                    preprocessing=models.module_scvi.PreprocessingConfig(n_top_genes=args.n_top_genes),
                 )
             elif args.model == "cansig":
                 config = models.CanSigConfig(
@@ -233,6 +237,7 @@ def generate_model_configs(args) -> List[Union[models.SCVIConfig, models.CanSigC
                     train=_scvi.TrainConfig(max_epochs=args.max_epochs),
                     continuous_covariates=args.continuous_covariates,
                     discrete_covariates=args.discrete_covariates,
+                    preprocessing=models.module_cansig.PreprocessingConfig(n_top_genes=args.n_top_genes),
                 )
             else:
                 raise NotImplementedError(f"Model {args.model} not implemented.")


### PR DESCRIPTION
When I ran CanSig on the simulated data set I noticed two issues:

 - In some places the batch column name wasn't passed and "sample_id" was used. This is not an issue on the cluster as we have standardized names after preprocessing and `sample_id` seems to occur everywhere.
 - In one of the old simulated data sets there aren't enough genes, so the default 2,000 needs to be overwritten by CLI parameters.

This PR also pins Sphinx version (it has recently been updated to 6.0.0, which doesn't seem to be backwards-compatible anymore and our deploys were failing).