### PR TITLE
Update for scvi-tools 0.20.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ scanpy>=1.9.1
 seaborn
 scikit-learn
 scipy
-scvi-tools<=0.19.0
+scvi-tools>=0.20.0
 sphinx<6
 statsmodels
 protobuf~=3.19.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,9 +25,7 @@ install_requires =
     scanpy>=1.9.1
     seaborn
     scipy
-    # At the moment of 2022-02-02 scVI has problems with dependencies
-    # so I decided to pin the version for now.
-    scvi-tools<=0.19.0
+    scvi-tools>=0.19.0
     statsmodels
     protobuf~=3.19.0
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ install_requires =
     scanpy>=1.9.1
     seaborn
     scipy
-    scvi-tools>=0.19.0
+    scvi-tools>=0.20.0
     statsmodels
     protobuf~=3.19.0
 

--- a/src/cansig/integration/model.py
+++ b/src/cansig/integration/model.py
@@ -1,9 +1,8 @@
-from typing import List, Optional
+from typing import List, Literal, Optional
 
 import anndata  # pytype: disable=import-error
 import scanpy as sc  # pytype: disable=import-error
 from anndata import AnnData  # pytype: disable=import-error
-from scvi._compat import Literal  # pytype: disable=import-error
 from scvi.data import AnnDataManager  # pytype: disable=import-error
 from scvi.data.fields import (  # pytype: disable=import-error
     CategoricalJointObsField,

--- a/src/cansig/integration/module/batcheffectvae.py
+++ b/src/cansig/integration/module/batcheffectvae.py
@@ -9,7 +9,7 @@ from cansig.integration._CONSTANTS import REGISTRY_KEYS  # pytype: disable=impor
 from cansig.integration.base.module import CanSigBaseModule  # pytype: disable=import-error
 from scvi._compat import Literal  # pytype: disable=import-error
 from scvi.distributions import NegativeBinomial, ZeroInflatedNegativeBinomial  # pytype: disable=import-error
-from scvi.module.base import LossRecorder, auto_move_data  # pytype: disable=import-error
+from scvi.module.base import LossOutput, auto_move_data  # pytype: disable=import-error
 from scvi.nn import DecoderSCVI, Encoder, one_hot  # pytype: disable=import-error
 from torch import logsumexp  # pytype: disable=import-error
 from torch.distributions import Normal, Poisson  # pytype: disable=import-error
@@ -383,7 +383,13 @@ class VAEBatchEffect(CanSigBaseModule):
 
         kl_local = dict(kl_divergence_l=kl_divergence_l, kl_divergence_z=kl_divergence_z)
         kl_global = torch.tensor(0.0)
-        return LossRecorder(loss, reconst_loss, kl_local, kl_global)
+
+        return LossOutput(
+            loss=loss,
+            reconstruction_loss=reconst_loss,
+            kl_local=kl_local,
+            kl_global=kl_global,
+        )
 
     @torch.no_grad()
     def sample(

--- a/src/cansig/integration/module/batcheffectvae.py
+++ b/src/cansig/integration/module/batcheffectvae.py
@@ -1,13 +1,12 @@
 # -*- coding: utf-8 -*-
 """Main module."""
-from typing import Callable, Iterable, Optional
+from typing import Callable, Iterable, Literal, Optional
 
 import numpy as np  # pytype: disable=import-error
 import torch  # pytype: disable=import-error
 import torch.nn.functional as F  # pytype: disable=import-error
 from cansig.integration._CONSTANTS import REGISTRY_KEYS  # pytype: disable=import-error
 from cansig.integration.base.module import CanSigBaseModule  # pytype: disable=import-error
-from scvi._compat import Literal  # pytype: disable=import-error
 from scvi.distributions import NegativeBinomial, ZeroInflatedNegativeBinomial  # pytype: disable=import-error
 from scvi.module.base import LossOutput, auto_move_data  # pytype: disable=import-error
 from scvi.nn import DecoderSCVI, Encoder, one_hot  # pytype: disable=import-error

--- a/src/cansig/integration/module/cnvvae.py
+++ b/src/cansig/integration/module/cnvvae.py
@@ -3,7 +3,7 @@ from typing import Iterable, Optional, Dict
 import torch  # pytype: disable=import-error
 import torch.nn as nn  # pytype: disable=import-error
 from scvi._compat import Literal  # pytype: disable=import-error
-from scvi.module.base import LossRecorder, auto_move_data  # pytype: disable=import-error
+from scvi.module.base import LossOutput, auto_move_data  # pytype: disable=import-error
 from scvi.nn import Encoder  # pytype: disable=import-error
 from scvi.nn import FCLayers  # pytype: disable=import-error
 from torch.distributions import Normal  # pytype: disable=import-error
@@ -190,7 +190,13 @@ class VAECNV(CanSigBaseModule):
 
         kl_local = dict(kl_loss=kl_loss)
         kl_global = torch.tensor(0.0)
-        return LossRecorder(loss, reconst_loss, kl_local, kl_global)
+
+        return LossOutput(
+            loss=loss,
+            reconstruction_loss=reconst_loss,
+            kl_local=kl_local,
+            kl_global=kl_global,
+        )
 
     def get_reconstruction_loss(self, x, x_hat) -> torch.Tensor:
         return self.reconstruction_loss(x, x_hat).sum(dim=1)

--- a/src/cansig/integration/module/cnvvae.py
+++ b/src/cansig/integration/module/cnvvae.py
@@ -1,8 +1,7 @@
-from typing import Iterable, Optional, Dict
+from typing import Dict, Iterable, Literal, Optional
 
 import torch  # pytype: disable=import-error
 import torch.nn as nn  # pytype: disable=import-error
-from scvi._compat import Literal  # pytype: disable=import-error
 from scvi.module.base import LossOutput, auto_move_data  # pytype: disable=import-error
 from scvi.nn import Encoder  # pytype: disable=import-error
 from scvi.nn import FCLayers  # pytype: disable=import-error

--- a/src/cansig/integration/module/vae.py
+++ b/src/cansig/integration/module/vae.py
@@ -9,7 +9,7 @@ from cansig.integration._CONSTANTS import REGISTRY_KEYS  # pytype: disable=impor
 from cansig.integration.base.module import CanSigBaseModule  # pytype: disable=import-error
 from scvi._compat import Literal  # pytype: disable=import-error
 from scvi.distributions import NegativeBinomial, ZeroInflatedNegativeBinomial  # pytype: disable=import-error
-from scvi.module.base import LossRecorder, auto_move_data  # pytype: disable=import-error
+from scvi.module.base import LossOutput, auto_move_data  # pytype: disable=import-error
 from scvi.nn import DecoderSCVI, Encoder, one_hot  # pytype: disable=import-error
 from torch.distributions import Normal, Poisson  # pytype: disable=import-error
 from torch.distributions import kl_divergence as kl  # pytype: disable=import-error
@@ -344,7 +344,13 @@ class VAECanSig(CanSigBaseModule):
 
         kl_local = dict(kl_divergence_l=kl_divergence_l, kl_divergence_z=kl_divergence_z)
         kl_global = torch.tensor(0.0)
-        return LossRecorder(loss, reconst_loss, kl_local, kl_global)
+
+        return LossOutput(
+            loss=loss,
+            reconstruction_loss=reconst_loss,
+            kl_local=kl_local,
+            kl_global=kl_global,
+        )
 
     @torch.no_grad()
     def sample(

--- a/src/cansig/integration/module/vae.py
+++ b/src/cansig/integration/module/vae.py
@@ -1,13 +1,12 @@
 # -*- coding: utf-8 -*-
 """Main module."""
-from typing import Callable, Iterable, Optional
+from typing import Callable, Iterable, Literal, Optional
 
 import numpy as np  # pytype: disable=import-error
 import torch  # pytype: disable=import-error
 import torch.nn.functional as F  # pytype: disable=import-error
 from cansig.integration._CONSTANTS import REGISTRY_KEYS  # pytype: disable=import-error
 from cansig.integration.base.module import CanSigBaseModule  # pytype: disable=import-error
-from scvi._compat import Literal  # pytype: disable=import-error
 from scvi.distributions import NegativeBinomial, ZeroInflatedNegativeBinomial  # pytype: disable=import-error
 from scvi.module.base import LossOutput, auto_move_data  # pytype: disable=import-error
 from scvi.nn import DecoderSCVI, Encoder, one_hot  # pytype: disable=import-error

--- a/src/cansig/integration/training/training_plan.py
+++ b/src/cansig/integration/training/training_plan.py
@@ -61,9 +61,6 @@ def _cycle_annealing(
     return beta
 
 
-# Ideally, we would inherit from scVI's trainingsplan, however, it calls the kl_weight
-# in the initializer and since CanSigTrainingPlan is not yet initialized it doesn't find
-# the property. There is probably a way of solving it, but I don't know how.
 class CanSigTrainingPlan(TrainingPlan):
     def __init__(
         self,
@@ -71,7 +68,7 @@ class CanSigTrainingPlan(TrainingPlan):
         *,
         optimizer: Literal["Adam", "AdamW", "Custom"] = "Adam",
         optimizer_creator: Optional[TorchOptimizerCreator] = None,
-        beta: float = 1.0,  # new 
+        beta: float = 1.0,
         annealing: Literal["linear", "cyclical"] = "linear",
         lr: float = 1e-3,
         weight_decay: float = 1e-6,

--- a/src/cansig/integration/training/training_plan.py
+++ b/src/cansig/integration/training/training_plan.py
@@ -1,12 +1,10 @@
-from inspect import getfullargspec
-from typing import Optional, Literal  # pytype: disable=not-supported-yet
+from typing import Literal, Optional  # pytype: disable=not-supported-yet
 
-import pytorch_lightning as pl  # pytype: disable=import-error
 import torch  # pytype: disable=import-error
 from scvi.module.base import LossOutput  # pytype: disable=import-error
+from scvi.train import TrainingPlan  # pytype: disable=import-error
 from scvi.train._metrics import ElboMetric  # pytype: disable=import-error
-from torch.optim.lr_scheduler import ReduceLROnPlateau  # pytype: disable=import-error
-
+from scvi.train._trainingplans import TorchOptimizerCreator
 
 from cansig.integration.base.module import CanSigBaseModule  # pytype: disable=import-error
 
@@ -66,16 +64,18 @@ def _cycle_annealing(
 # Ideally, we would inherit from scVI's trainingsplan, however, it calls the kl_weight
 # in the initializer and since CanSigTrainingPlan is not yet initialized it doesn't find
 # the property. There is probably a way of solving it, but I don't know how.
-class CanSigTrainingPlan(pl.LightningModule):
+class CanSigTrainingPlan(TrainingPlan):
     def __init__(
         self,
         module: CanSigBaseModule,
-        optimizer: Literal["Adam", "AdamW"] = "Adam",
-        beta: float = 1.0,
+        *,
+        optimizer: Literal["Adam", "AdamW", "Custom"] = "Adam",
+        optimizer_creator: Optional[TorchOptimizerCreator] = None,
+        beta: float = 1.0,  # new 
         annealing: Literal["linear", "cyclical"] = "linear",
+        lr: float = 1e-3,
+        weight_decay: float = 1e-6,
         eps: float = 0.01,
-        lr=1e-3,
-        weight_decay=1e-6,
         n_steps_kl_warmup: Optional[int] = None,
         n_epochs_kl_warmup: Optional[int] = 400,
         reduce_lr_on_plateau: bool = False,
@@ -88,34 +88,25 @@ class CanSigTrainingPlan(pl.LightningModule):
         lr_min: Optional[float] = None,
         **loss_kwargs,
     ):
-        super().__init__()
+        super().__init__(
+            module,
+            optimizer=optimizer,
+            optimizer_creator=optimizer_creator,
+            lr=lr,
+            weight_decay=weight_decay,
+            eps=eps,
+            n_steps_kl_warmup=n_steps_kl_warmup,
+            n_epochs_kl_warmup=n_epochs_kl_warmup,
+            reduce_lr_on_plateau=reduce_lr_on_plateau,
+            lr_factor=lr_factor,
+            lr_patience=lr_patience,
+            lr_scheduler_metric=lr_scheduler_metric,
+            lr_threshold=lr_threshold,
+            lr_min=lr_min,
+            **loss_kwargs,
+        )
         self.annealing = annealing
         self.beta = beta
-        self.module = module
-        self.lr = lr
-        self.weight_decay = weight_decay
-        self.eps = eps
-        self.optimizer_name = optimizer
-        self.n_steps_kl_warmup = n_steps_kl_warmup
-        self.n_epochs_kl_warmup = n_epochs_kl_warmup
-        self.reduce_lr_on_plateau = reduce_lr_on_plateau
-        self.lr_factor = lr_factor
-        self.lr_patience = lr_patience
-        self.lr_scheduler_metric = lr_scheduler_metric
-        self.lr_threshold = lr_threshold
-        self.lr_min = lr_min
-        self.loss_kwargs = loss_kwargs
-
-        self._n_obs_training = None
-        self._n_obs_validation = None
-
-        # automatic handling of kl weight
-        self._loss_args = getfullargspec(self.module.loss)[0]
-        if "kl_weight" in self._loss_args:
-            self.loss_kwargs.update({"kl_weight": self.kl_weight})
-
-        self.initialize_train_metrics()
-        self.initialize_val_metrics()
 
     def initialize_train_metrics(self):
         """Initialize train related metrics."""
@@ -126,48 +117,6 @@ class CanSigTrainingPlan(pl.LightningModule):
         """Initialize train related metrics."""
         self.elbo_val = ElboMetric(self.n_obs_validation, mode="validation")
         self.elbo_val.reset()
-
-    @property
-    def n_obs_training(self):
-        """
-        Number of observations in the training set.
-
-        This will update the loss kwargs for loss rescaling.
-
-        Notes
-        -----
-        This can get set after initialization
-        """
-        return self._n_obs_training
-
-    @n_obs_training.setter
-    def n_obs_training(self, n_obs: int):
-        if "n_obs" in self._loss_args:
-            self.loss_kwargs.update({"n_obs": n_obs})
-        self._n_obs_training = n_obs
-        self.initialize_train_metrics()
-
-    @property
-    def n_obs_validation(self):
-        """
-        Number of observations in the validation set.
-
-        This will update the loss kwargs for loss rescaling.
-
-        Notes
-        -----
-        This can get set after initialization
-        """
-        return self._n_obs_validation
-
-    @n_obs_validation.setter
-    def n_obs_validation(self, n_obs: int):
-        self._n_obs_validation = n_obs
-        self.initialize_val_metrics()
-
-    def forward(self, *args, **kwargs):
-        """Passthrough to `model.forward()`."""
-        return self.module(*args, **kwargs)
 
     def training_step(self, batch, batch_idx, optimizer_idx=0):
         if "kl_weight" in self.loss_kwargs:
@@ -184,34 +133,6 @@ class CanSigTrainingPlan(pl.LightningModule):
         _, _, scvi_loss = self.forward(batch, loss_kwargs=self.loss_kwargs)
         self.log("validation_loss", scvi_loss.loss, on_epoch=True)
         self.compute_and_log_metrics(scvi_loss, self.elbo_val)
-
-    def configure_optimizers(self):
-        params = filter(lambda p: p.requires_grad, self.module.parameters())
-        if self.optimizer_name == "Adam":
-            optim_cls = torch.optim.Adam  # pytype: disable=module-attr
-        elif self.optimizer_name == "AdamW":
-            optim_cls = torch.optim.AdamW  # pytype: disable=module-attr
-        else:
-            raise ValueError("Optimizer not understood.")
-        optimizer = optim_cls(params, lr=self.lr, eps=self.eps, weight_decay=self.weight_decay)
-        config = {"optimizer": optimizer}
-        if self.reduce_lr_on_plateau:
-            scheduler = ReduceLROnPlateau(
-                optimizer,
-                patience=self.lr_patience,
-                factor=self.lr_factor,
-                threshold=self.lr_threshold,
-                min_lr=self.lr_min,
-                threshold_mode="abs",
-                verbose=True,
-            )
-            config.update(
-                {
-                    "lr_scheduler": scheduler,
-                    "monitor": self.lr_scheduler_metric,
-                },
-            )
-        return config
 
     @property
     def kl_weight(self):


### PR DESCRIPTION
This PR integrates necessary changes for updating to scvi-tools v0.20.0, resolving #101.
- Replace `LossRecorder` instances with `LossOutput`
- Set `scvi-tools>=0.20.0`
- Refresh `CanSigTrainingPlan` to inherit from `scvi.train.TrainingPlan`